### PR TITLE
Fetch emlib hash when building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
 Cargo.lock
 target/
-Makefile.user
+.emlib_hash
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 Cargo.lock
 target/
 .emlib_hash
-
+Makefile.user

--- a/Makefile
+++ b/Makefile
@@ -9,41 +9,34 @@ TARGET=thumbv7m-none-eabi
 PROJ_DIR  = examples
 PROJ_NAME = buttons_int
 
-RUSTC = $(RUSTC_PATH)rustc
+RUSTC = rustc
 FLASH = eACommander
 
-HASH =
-
-
-
-LIB_PATH = $(SIMPLICITY_STUDIO_HOME)/developer/sdks/efm32/v2
-LIB_DIR = lib
+-include .emlib_hash
 
 TARGET_DIR = target/$(TARGET)
 TARGET_OUT = $(TARGET_DIR)/$(PROJ_NAME)
 
-.PHONY: all setup proj flash clean clean_all
+.PHONY: all setup proj flash clean libemlib
 
 all:    proj
 proj:   $(TARGET_OUT).elf $(TARGET_OUT).hex $(TARGET_OUT).bin
 
 AFLAGS   = -mthumb -mcpu=cortex-m3
-LDFLAGS  = $(AFLAGS) -T$(LIB_PATH)/Device/SiliconLabs/EFM32GG/Source/GCC/efm32gg.ld
+LDFLAGS  = $(AFLAGS) -Tefm32-common/Device/EFM32GG/Source/GCC/efm32gg.ld
 LDFLAGS += -Wl,--start-group -lgcc -lc -lnosys -Wl,--end-group
-
--include Makefile.user
 
 RUSTFLAGS  = --target $(TARGET) --crate-type bin
 RUSTFLAGS += -g -C link-args="$(LDFLAGS)"
-RUSTFLAGS += -L $(LIB_DIR) -L $(TARGET_DIR) -L $(TARGET_DIR)/deps -L $(TARGET_DIR)/build/emlib-$(HASH)/out
+RUSTFLAGS += -L $(TARGET_DIR) -L $(TARGET_DIR)/deps -L $(TARGET_DIR)/build/emlib-$(HASH)/out
 RUSTFLAGS += --emit=dep-info,link --verbose
 
 FLASHFLAGS = --verify --reset
 
-%.elf: $(PROJ_DIR)/$(PROJ_NAME).rs 
-	cargo build --target thumbv7m-none-eabi
-	arm-none-eabi-ar -x $(TARGET_DIR)/libemlib-$(HASH).rlib
-	mv emlib-$(HASH).o emlib-$(HASH).0.bytecode.deflate rust.metadata.bin target/thumbv7m-none-eabi
+%.elf: $(PROJ_DIR)/$(PROJ_NAME).rs libemlib
+	cargo build --target thumbv7m-none-eabi --verbose
+	@$(AR) -x $(TARGET_DIR)/libemlib-$(HASH).rlib
+	@mv *.o emlib-$(HASH).0.bytecode.deflate rust.metadata.bin $(TARGET_DIR)
 	$(RUSTC) $< $(RUSTFLAGS) --out-dir $(TARGET_DIR) --crate-name $(PROJ_NAME)
 
 %.hex: %

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ PROJ_NAME = buttons_int
 RUSTC = rustc
 FLASH = eACommander
 
--include Makefile.user
 -include .emlib_hash
 
 TARGET_DIR = target/$(TARGET)
@@ -26,6 +25,8 @@ proj:   $(TARGET_OUT).elf $(TARGET_OUT).hex $(TARGET_OUT).bin
 AFLAGS   = -mthumb -mcpu=cortex-m3
 LDFLAGS  = $(AFLAGS) -Tefm32-common/Device/EFM32GG/Source/GCC/efm32gg.ld
 LDFLAGS += -Wl,--start-group -lgcc -lc -lnosys -Wl,--end-group
+
+-include Makefile.user
 
 RUSTFLAGS  = --target $(TARGET) --crate-type bin
 RUSTFLAGS += -g -C link-args="$(LDFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ PROJ_NAME = buttons_int
 RUSTC = rustc
 FLASH = eACommander
 
+-include Makefile.user
 -include .emlib_hash
 
 TARGET_DIR = target/$(TARGET)

--- a/examples/buttons_int.rs
+++ b/examples/buttons_int.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(core, lang_items)]
+#![feature(core, lang_items, no_std)]
 
 
 extern crate core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![crate_type="lib"]
 #![crate_name="emlib"]
-#![feature(core, lang_items)]
+#![feature(core, lang_items, no_std)]
 
 extern crate core;
 


### PR DESCRIPTION
- Removed `Makefile.user` and replaced it with the generated file `.emlib_hash`. This serves as a temporary hack to feed the HASH to the Makefile. This is still not optimal, as it will fail the first time `make` is ran in an empty project (because the hash does not yet exist). If we want to fix this, the easiest solution could e.g. be to make a `configure` script that runs `cargo build --target thumbv7m-none-eabi`.
- `RUSTC_PATH` is no longer in use, since we're building against nightly
- Refer to the `efm32gg.ld` in `efm32-common` instead of SimplicityStudio
- Add `no_std` feature flags to library and executables, as required by latest nightly
