### PR TITLE
Added support for simple dma example

### DIFF
--- a/build/emlib.rs
+++ b/build/emlib.rs
@@ -33,20 +33,24 @@ fn compile_emlib_library() {
         "efm32-common/Device/EFM32GG/Source/GCC/startup_efm32gg.S",
         "efm32-common/Device/EFM32GG/Source/system_efm32gg.c",
         "efm32-common/emlib/src/em_cmu.c",
+        "efm32-common/emlib/src/em_dma.c",
         "efm32-common/emlib/src/em_emu.c",
         "efm32-common/emlib/src/em_gpio.c",
         "efm32-common/emlib/src/em_rtc.c",
         "efm32-common/emlib/src/em_system.c",
         "efm32-common/emlib/src/em_timer.c",
         "efm32-common/emlib/src/em_int.c",
+        "efm32-common/kits/common/drivers/dmactrl.c",
         "efm32-common/kits/common/drivers/retargetio.c",
         "efm32-common/emdrv/gpiointerrupt/src/gpiointerrupt.c",
 
         "src/chip/chip.c",
         "src/cmsis/cmsis.c",
+        "src/dma/dma.c",
         "src/gpio/gpio.c",
         "src/rtc/rtc.c",
         "src/timer/timer.c",
+        
         "src/emdrv/gpiointerrupt.c",
     ];
 

--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+#![feature(lang_items, core)]
+
+extern crate core;
+extern crate emlib;
+
+use emlib::{chip, dma};
+
+static mut DATA_SRC: [u16; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+static mut DATA_DST: [u16; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
+
+static CB: dma::CB = dma::CB {
+    cb_func: transfer_complete,
+    user_ptr: 0,
+    primary: 0
+};
+
+#[no_mangle]
+pub extern fn main() {
+
+    chip::init();
+
+    setup_dma();
+
+    let dma0 = dma::DMA::channel0();
+    unsafe { dma0.activate_auto(true, &mut DATA_DST, &mut DATA_SRC); }
+    
+    loop {}
+}
+
+extern fn transfer_complete(_channel: u32, _primary: bool, _user: u32) {}
+
+fn setup_dma() {
+    
+    dma::init(&dma::Init{
+        hprot: 0,
+        control_block: dma::dma_control_block(),
+    });
+
+    let dma0 = dma::DMA::channel0();
+    dma0.configure_channel(&dma::CfgChannel {
+        high_pri: false,
+        enable_int: true,
+        select: 0,
+        cb: &CB,
+    }); 
+    dma0.configure_descriptor(true, &dma::CfgDescriptor {
+        dst_inc: dma::DataInc::Inc4,
+        src_inc: dma::DataInc::Inc4,
+        size: dma::DataSize::Size4,
+        arb_rate: dma::ArbiterConfig::Arbitrate1,
+        hprot: 0,
+    });
+}
+
+#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
+#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }

--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(lang_items, core)]
+#![feature(lang_items, core, no_std)]
 
 extern crate core;
 extern crate emlib;

--- a/src/cmu/mod.rs
+++ b/src/cmu/mod.rs
@@ -3,6 +3,7 @@
 pub enum Clock {
     LFA    = 0x60002,
     CORE   = 0x40020,
+    DMA    = 0x40300,
     HFPER  = 0x28110,
     GPIO   = 0x2d200,
     CORELE = 0x44300,

--- a/src/dma/dma.c
+++ b/src/dma/dma.c
@@ -1,0 +1,6 @@
+#include "em_dma.h"
+#include "dmactrl.h"
+
+DMA_DESCRIPTOR_TypeDef* GET_DMA_CONTROL_BLOCK() {
+    return dmaControlBlock;
+}

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -1,0 +1,148 @@
+#![allow(dead_code)]
+
+#[repr(u8)]
+pub enum c_void {
+    __variant1,
+    __variant2,
+}
+
+pub const DMAREQ_TIMER0_UFOF: u32 = ((24 << 16) + 0);
+
+pub type FuncPtr = extern fn(channel: u32, primary: bool, user: u32);
+
+use core::intrinsics::transmute;
+use core::default::Default;
+use core::option::Option;
+use core::slice::SliceExt;
+use core::ptr;
+
+pub struct DMA { channel: u32 }
+
+impl DMA {
+    pub fn channel0() -> DMA {
+        DMA { channel: 0 }
+    }
+
+    pub fn configure_channel(&self, cfg: &CfgChannel) {
+        unsafe { DMA_CfgChannel(self.channel, cfg) }
+    }
+
+    pub fn configure_descriptor(&self, primary: bool, cfg: &CfgDescriptor) {
+        unsafe { DMA_CfgDescr(self.channel, primary, cfg) }
+    }
+
+    pub fn activate_auto<T>(&self, primary: bool, dst: &mut[T], src: &mut[T]) {
+        unsafe {
+
+            let (dst_n, src_n) = (dst.len(), src.len());
+
+            let n = if dst_n < src_n { dst_n } else { src_n };
+            
+            DMA_ActivateAuto(
+                self.channel,
+                primary,
+                transmute(dst.as_ptr()),
+                transmute(src.as_ptr()),
+                n - 1
+            );
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct Init {
+    pub hprot: u8,
+    pub control_block: &'static Descriptor,
+}
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct CfgChannel {
+    pub high_pri: bool,
+    pub enable_int: bool,
+    pub select: u32,
+    pub cb: &'static CB,
+}
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct CfgDescriptor {
+    pub dst_inc: DataInc,
+    pub src_inc: DataInc,
+    pub size: DataSize,
+    pub arb_rate: ArbiterConfig,
+    pub hprot: u8,
+}
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct Descriptor {
+    pub SRCEND: u32,
+    pub DSTEND: u32,
+    pub CTRL: u32,
+    pub USER: u32,
+}
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct CB {
+    pub cb_func: FuncPtr,
+    pub user_ptr: u32,
+    pub primary: u8,
+}
+
+#[repr(u8)]
+#[derive(Copy)]
+pub enum DataInc {
+    Inc1 = 0x0,
+    Inc2 = 0x1,
+    Inc4 = 0x2,
+    IncNone = 0x3,
+}
+
+#[repr(u8)]
+#[derive(Copy)]
+pub enum DataSize {
+    Size1 = 0x0,
+    Size2 = 0x1,
+    Size4 = 0x2,
+}
+
+#[repr(u8)]
+#[derive(Copy)]
+pub enum ArbiterConfig {
+    Arbitrate1 = 0x0,
+    Arbitrate2 = 0x1,
+    Arbitrate4 = 0x2,
+    Arbitrate8 = 0x3,
+    Arbitrate16 = 0x4,
+    Arbitrate32 = 0x5,
+    Arbitrate64 = 0x6,
+    Arbitrate128 = 0x7,
+    Arbitrate256 = 0x8,
+    Arbitrate512 = 0x9,
+    Arbitrate1024 = 0xa,
+}
+
+pub fn init(init: &Init) {
+    unsafe { DMA_Init(init) }
+}
+
+pub fn dma_control_block() -> &'static Descriptor {
+    unsafe { transmute(GET_DMA_CONTROL_BLOCK()) }
+}
+
+extern {
+    fn GET_DMA_CONTROL_BLOCK() -> &'static Descriptor;
+
+    fn DMA_Init(init: &Init);
+    fn DMA_CfgChannel(channel: u32, cfg: &CfgChannel);
+    fn DMA_CfgDescr(channel: u32, primary: bool, cfg: &CfgDescriptor);
+    fn DMA_ActivateAuto(
+        channel: u32,
+        use_burst: bool,
+        dst: *mut c_void,
+        src: *mut c_void,
+        n_minus_1: usize);
+}

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+
 use core::intrinsics::transmute;
 use core::slice::SliceExt;
 use core::cmp::min;
@@ -32,7 +33,7 @@ impl DMA {
         unsafe { DMA_CfgDescr(self.channel, primary, cfg) }
     }
 
-    pub fn activate_auto<T>(&self, primary: bool, dst: &mut[T], src: &mut[T]) {
+    pub fn activate_auto<T>(&self, primary: bool, dst: &'static mut[T], src: &'static mut[T]) {
         unsafe {
 
             let n = min(dst.len(), src.len());
@@ -133,11 +134,17 @@ pub fn dma_control_block() -> &'static Descriptor {
     unsafe { transmute(GET_DMA_CONTROL_BLOCK()) }
 }
 
+
 extern {
     fn GET_DMA_CONTROL_BLOCK() -> &'static Descriptor;
 
+    #[allow(warnings)]
     fn DMA_Init(init: *const Init);
+
+    #[allow(warnings)]
     fn DMA_CfgChannel(channel: u32, cfg: *const CfgChannel);
+
+    #[allow(warnings)]
     fn DMA_CfgDescr(channel: u32, primary: bool, cfg: *const CfgDescriptor);
     fn DMA_ActivateAuto(
         channel: u32,

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -36,8 +36,8 @@ impl DMA {
     pub fn activate_auto<T>(&self, primary: bool, dst: &'static mut[T], src: &'static mut[T]) {
         unsafe {
 
-            let n = min(dst.len(), src.len());
-            
+            let n = min(dst.len(), src.len()) as u32;
+
             DMA_ActivateAuto(
                 self.channel,
                 primary,
@@ -135,21 +135,19 @@ pub fn dma_control_block() -> &'static Descriptor {
 }
 
 
+#[allow(warnings)]
 extern {
     fn GET_DMA_CONTROL_BLOCK() -> &'static Descriptor;
 
-    #[allow(warnings)]
     fn DMA_Init(init: *const Init);
 
-    #[allow(warnings)]
     fn DMA_CfgChannel(channel: u32, cfg: *const CfgChannel);
 
-    #[allow(warnings)]
     fn DMA_CfgDescr(channel: u32, primary: bool, cfg: *const CfgDescriptor);
     fn DMA_ActivateAuto(
         channel: u32,
         use_burst: bool,
         dst: *mut c_void,
         src: *mut c_void,
-        n_minus_1: usize);
+        n_minus_1: u32);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate core;
 
 pub mod chip;
 pub mod cmu;
+pub mod dma;
 pub mod gpio;
 pub mod timer;
 


### PR DESCRIPTION
To test the example:
- Run with gdb
- Break at main and `print dma::DATA_DST`
- Continue to loop {} and `print dma::DATA_DST`
  The contents should now have changed
