### PR TITLE
Cleanup library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 script:
   - cargo build --target thumbv7m-none-eabi --verbose
-  - make
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ DEVICE=EFM32GG990F1024
 TARGET=thumbv7m-none-eabi
 
 EXAMPLE_DIR = examples
-EXAMPLE     = buttons_int
+EXAMPLES    = $(wildcard $(EXAMPLE_DIR)/*.rs)
+
+PROJ_NAME   = buttons_int
 
 RUSTC = rustc
 FLASH = eACommander
@@ -15,12 +17,12 @@ FLASH = eACommander
 -include .emlib_hash
 
 TARGET_DIR = target/$(TARGET)
-TARGET_OUT = $(TARGET_DIR)/$(EXAMPLE)
+TARGET_OUT = $(TARGET_DIR)/$(PROJ_NAME)
 
-.PHONY: all setup proj flash clean
+.PHONY: all setup proj flash test clean
 
 all:    proj
-proj:   $(TARGET_OUT).elf $(TARGET_OUT).hex $(TARGET_OUT).bin
+proj:   $(PROJ_NAME).elf $(TARGET_OUT).hex $(TARGET_OUT).bin
 
 AFLAGS   = -mthumb -mcpu=cortex-m3
 LDFLAGS  = $(AFLAGS) -Tefm32-common/Device/EFM32GG/Source/GCC/efm32gg.ld
@@ -35,11 +37,11 @@ RUSTFLAGS += --emit=dep-info,link --verbose
 
 FLASHFLAGS = --verify --reset
 
-%.elf: $(EXAMPLE_DIR)/$(EXAMPLE).rs
+%.elf: $(EXAMPLE_DIR)/$(@:.elf=.rs)
 	cargo build --target thumbv7m-none-eabi --verbose
 	@$(AR) -x $(TARGET_DIR)/libemlib-$(HASH).rlib
 	@mv *.o emlib-$(HASH).0.bytecode.deflate rust.metadata.bin $(TARGET_DIR)
-	$(RUSTC) $< $(RUSTFLAGS) --out-dir $(TARGET_DIR) --crate-name $(EXAMPLE)
+	$(RUSTC) $<$(@:.elf=.rs) $(RUSTFLAGS) --out-dir $(TARGET_DIR) --crate-name $(@:.elf=)
 
 %.hex: %
 	$(OBJCOPY) -O ihex $< $@
@@ -49,6 +51,9 @@ FLASHFLAGS = --verify --reset
 
 flash: all
 	$(FLASH) --flash $(TARGET_OUT).bin $(FLASHFLAGS)
+
+test: $(notdir $(EXAMPLES:.rs=.elf))
+	@echo Done
 
 clean:
 	@cargo clean

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ OBJCOPY = arm-none-eabi-objcopy
 DEVICE=EFM32GG990F1024
 TARGET=thumbv7m-none-eabi
 
-PROJ_DIR  = examples
-PROJ_NAME = buttons_int
+EXAMPLE_DIR = examples
+EXAMPLE     = buttons_int
 
 RUSTC = rustc
 FLASH = eACommander
@@ -15,7 +15,7 @@ FLASH = eACommander
 -include .emlib_hash
 
 TARGET_DIR = target/$(TARGET)
-TARGET_OUT = $(TARGET_DIR)/$(PROJ_NAME)
+TARGET_OUT = $(TARGET_DIR)/$(EXAMPLE)
 
 .PHONY: all setup proj flash clean
 
@@ -35,11 +35,11 @@ RUSTFLAGS += --emit=dep-info,link --verbose
 
 FLASHFLAGS = --verify --reset
 
-%.elf: $(PROJ_DIR)/$(PROJ_NAME).rs
+%.elf: $(EXAMPLE_DIR)/$(EXAMPLE).rs
 	cargo build --target thumbv7m-none-eabi --verbose
 	@$(AR) -x $(TARGET_DIR)/libemlib-$(HASH).rlib
 	@mv *.o emlib-$(HASH).0.bytecode.deflate rust.metadata.bin $(TARGET_DIR)
-	$(RUSTC) $< $(RUSTFLAGS) --out-dir $(TARGET_DIR) --crate-name $(PROJ_NAME)
+	$(RUSTC) $< $(RUSTFLAGS) --out-dir $(TARGET_DIR) --crate-name $(EXAMPLE)
 
 %.hex: %
 	$(OBJCOPY) -O ihex $< $@

--- a/build/emlib.rs
+++ b/build/emlib.rs
@@ -44,6 +44,7 @@ fn compile_emlib_library() {
 
         "src/chip/chip.c",
         "src/cmsis/cmsis.c",
+        "src/emu/emu.c",
         "src/gpio/gpio.c",
         "src/rtc/rtc.c",
         "src/timer/timer.c",

--- a/examples/buttons_int.rs
+++ b/examples/buttons_int.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![feature(core, lang_items, no_std)]
 
-
 extern crate core;
 extern crate emlib;
 
@@ -47,7 +46,6 @@ fn gpio_setup() {
 
 #[no_mangle]
 pub extern fn main() {
-
     chip::init();
 
     gpio_setup();

--- a/examples/energy_modes.rs
+++ b/examples/energy_modes.rs
@@ -53,14 +53,12 @@ pub extern fn main() {
     gpio::pin_mode_set(gpio::Port::E, LED1, gpio::Mode::PushPull, 0);
 
     loop {
-        unsafe {
-            match mode {
-                1 => emu::enter_em1(),
-                2 => emu::enter_em2(true),
-                3 => emu::enter_em3(true),
-                4 => emu::enter_em4(),
-                _ => ()
-            }
+        match unsafe { mode } {
+            1 => emu::enter_em1(),
+            2 => emu::enter_em2(true),
+            3 => emu::enter_em3(true),
+            4 => emu::enter_em4(),
+            _ => ()
         }
     }
 }

--- a/examples/energy_modes.rs
+++ b/examples/energy_modes.rs
@@ -1,0 +1,70 @@
+#![no_std]
+#![no_main]
+#![feature(core, lang_items, no_std)]
+
+extern crate core;
+extern crate emlib;
+
+use emlib::chip;
+use emlib::cmu;
+use emlib::gpio;
+use emlib::emu;
+use emlib::emdrv::gpioint;
+
+const LED0: u32 = 2;
+const LED1: u32 = 3;
+
+const PB0: u32 = 9;
+const PB1: u32 = 10;
+
+static mut mode: u32 = 0;
+
+extern fn button_callback(pin: u8) {
+    if pin == 9 {
+        unsafe { mode += 1; }
+    } else {
+        unsafe { mode -= 1; }
+    }
+}
+
+fn gpio_setup() {
+    cmu::clock_enable(cmu::Clock::GPIO, true);
+
+    gpio::pin_mode_set(gpio::Port::B, PB0, gpio::Mode::Input, 0);
+    gpio::pin_mode_set(gpio::Port::B, PB1, gpio::Mode::Input, 0);
+
+    gpioint::init();
+
+    gpioint::callback_register(PB0 as u8, button_callback);
+    gpioint::callback_register(PB1 as u8, button_callback);
+
+    gpio::int_config(gpio::Port::B, PB0, false, true, true);
+    gpio::int_config(gpio::Port::B, PB1, false, true, true);
+
+}
+
+#[no_mangle]
+pub extern fn main() {
+    chip::init();
+
+    gpio_setup();
+
+    gpio::pin_mode_set(gpio::Port::E, LED0, gpio::Mode::PushPull, 0);
+    gpio::pin_mode_set(gpio::Port::E, LED1, gpio::Mode::PushPull, 0);
+
+    loop {
+        unsafe {
+            match mode {
+                1 => emu::enter_em1(),
+                2 => emu::enter_em2(true),
+                3 => emu::enter_em3(true),
+                4 => emu::enter_em4(),
+                _ => ()
+            }
+        }
+    }
+}
+
+#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
+#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }

--- a/examples/energy_modes.rs
+++ b/examples/energy_modes.rs
@@ -11,9 +11,6 @@ use emlib::gpio;
 use emlib::emu;
 use emlib::emdrv::gpioint;
 
-const LED0: u32 = 2;
-const LED1: u32 = 3;
-
 const PB0: u32 = 9;
 const PB1: u32 = 10;
 
@@ -48,9 +45,6 @@ pub extern fn main() {
     chip::init();
 
     gpio_setup();
-
-    gpio::pin_mode_set(gpio::Port::E, LED0, gpio::Mode::PushPull, 0);
-    gpio::pin_mode_set(gpio::Port::E, LED1, gpio::Mode::PushPull, 0);
 
     loop {
         match unsafe { mode } {

--- a/examples/rtc_blink.rs
+++ b/examples/rtc_blink.rs
@@ -1,0 +1,73 @@
+#![no_std]
+#![no_main]
+#![feature(lang_items, core, no_std)]
+
+extern crate core;
+extern crate emlib;
+
+use core::default::Default;
+
+use emlib::cmsis::nvic;
+use emlib::cmu;
+use emlib::chip;
+use emlib::gpio;
+use emlib::rtc;
+
+const LFXO_FREQ: u32 = 32768;
+const RTC_TIMEOUT_S: u32 = 2;
+
+fn rtc_setup() {
+    let rtc_init = rtc::Init { enable: false, .. Default::default() };
+
+    /* Enable LE domain registers */
+    cmu::clock_enable(cmu::Clock::CORELE, true);
+
+    /* Enable LFXO as LFACLK in CMU. This will also start LFXO */
+    cmu::clock_select_set(cmu::Clock::LFA, cmu::Select::LFXO);
+
+    /* Enable RTC clock */
+    cmu::clock_enable(cmu::Clock::RTC, true);
+
+    rtc::init(&rtc_init);
+
+    /* Interrupt every second */
+    rtc::compare_set(0, LFXO_FREQ * RTC_TIMEOUT_S);
+
+    /* Enable interrupt */
+    nvic::enable_irq(nvic::IRQn::RTC);
+    rtc::int_enable(rtc::RTC_IEN_COMP0);
+
+    /* Start Counter */
+    rtc::enable(true);
+}
+
+fn gpio_setup() {
+    cmu::clock_enable(cmu::Clock::GPIO, true);
+
+    gpio::pin_mode_set(gpio::Port::E, 2, gpio::Mode::PushPullDrive, 0);
+    gpio::pin_out_clear(gpio::Port::E, 2);
+}
+
+#[no_mangle]
+pub extern fn main() {
+    chip::init();
+
+    rtc_setup();
+
+    gpio_setup();
+
+    loop { }
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern fn RTC_IRQHandler() {
+    /* Clear interrupt source */
+    rtc::int_clear(rtc::RTC_IEN_COMP0);
+
+    gpio::pin_out_toggle(gpio::Port::E, 2);
+}
+
+#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
+#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(lang_items, core)]
-
+#![feature(lang_items, core, no_std)]
 
 extern crate core;
 extern crate emlib;
@@ -23,7 +22,6 @@ pub extern fn TIMER0_IRQHandler() {
 
 #[no_mangle]
 pub extern fn main() {
-
     chip::init();
 
     cmu::clock_enable(cmu::Clock::HFPER, true);
@@ -42,13 +40,13 @@ pub extern fn main() {
     let timer0 = timer::Timer::timer0();
 
     timer0.int_enable(timer::TIMER_IF_OF);
-    nvic::enable_IRQ(nvic::IRQn::TIMER0);
+    nvic::enable_irq(nvic::IRQn::TIMER0);
     timer0.top_set(TOP);
     timer0.init(&timer_init);
 
     loop {}
-    
 }
+
 #[lang = "stack_exhausted"] extern fn stack_exhausted() {}
 #[lang = "eh_personality"] extern fn eh_personality() {}
 #[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }

--- a/src/cmsis/nvic.rs
+++ b/src/cmsis/nvic.rs
@@ -1,123 +1,122 @@
 #[repr(C)]
 pub enum IRQn {
 /******  Cortex-M3 Processor Exceptions Numbers *******************************************/
-  NonMaskableInt   = -14,
-  HardFault        = -13,
-  MemoryManagement = -12,
-  BusFault         = -11,
-  UsageFault       = -10,
-  SVCall           = -5,
-  DebugMonitor     = -4,
-  PendSV           = -2,
-  SysTick          = -1,
+    NonMaskableInt   = -14,
+    HardFault        = -13,
+    MemoryManagement = -12,
+    BusFault         = -11,
+    UsageFault       = -10,
+    SVCall           = -5,
+    DebugMonitor     = -4,
+    PendSV           = -2,
+    SysTick          = -1,
 
 /******  EFM32G Peripheral Interrupt Numbers **********************************************/
-  DMA              = 0,
-  GPIO_EVEN        = 1,
-  TIMER0           = 2,
-  USART0_RX        = 3,
-  USART0_TX        = 4,
-  USB              = 5,
-  ACMP0            = 6,
-  ADC0             = 7,
-  DAC0             = 8,
-  I2C0             = 9,
-  I2C1             = 10,
-  GPIO_ODD         = 11,
-  TIMER1           = 12,
-  TIMER2           = 13,
-  TIMER3           = 14,
-  USART1_RX        = 15,
-  USART1_TX        = 16,
-  LESENSE          = 17,
-  USART2_RX        = 18,
-  USART2_TX        = 19,
-  UART0_RX         = 20,
-  UART0_TX         = 21,
-  UART1_RX         = 22,
-  UART1_TX         = 23,
-  LEUART0          = 24,
-  LEUART1          = 25,
-  LETIMER0         = 26,
-  PCNT0            = 27,
-  PCNT1            = 28,
-  PCNT2            = 29,
-  RTC              = 30,
-  BURTC            = 31,
-  CMU              = 32,
-  VCMP             = 33,
-  LCD              = 34,
-  MSC              = 35,
-  AES              = 36,
-  EBI              = 37,
-  EMU              = 38,
+    DMA              = 0,
+    GPIO_EVEN        = 1,
+    TIMER0           = 2,
+    USART0_RX        = 3,
+    USART0_TX        = 4,
+    USB              = 5,
+    ACMP0            = 6,
+    ADC0             = 7,
+    DAC0             = 8,
+    I2C0             = 9,
+    I2C1             = 10,
+    GPIO_ODD         = 11,
+    TIMER1           = 12,
+    TIMER2           = 13,
+    TIMER3           = 14,
+    USART1_RX        = 15,
+    USART1_TX        = 16,
+    LESENSE          = 17,
+    USART2_RX        = 18,
+    USART2_TX        = 19,
+    UART0_RX         = 20,
+    UART0_TX         = 21,
+    UART1_RX         = 22,
+    UART1_TX         = 23,
+    LEUART0          = 24,
+    LEUART1          = 25,
+    LETIMER0         = 26,
+    PCNT0            = 27,
+    PCNT1            = 28,
+    PCNT2            = 29,
+    RTC              = 30,
+    BURTC            = 31,
+    CMU              = 32,
+    VCMP             = 33,
+    LCD              = 34,
+    MSC              = 35,
+    AES              = 36,
+    EBI              = 37,
+    EMU              = 38,
 }
 
 extern {
-    pub fn STATIC_INLINE_NVIC_SetPriorityGrouping(PriorityGroup: u32);
+    pub fn STATIC_INLINE_NVIC_SetPriorityGrouping(priority_group: u32);
     pub fn STATIC_INLINE_NVIC_GetPriorityGrouping();
-    pub fn STATIC_INLINE_NVIC_EnableIRQ(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_DisableIRQ(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_GetPendingIRQ(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_SetPendingIRQ(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_ClearPendingIRQ(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_GetActive(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_SetPriority(IRQn: IRQn, priority: u32);
-    pub fn STATIC_INLINE_NVIC_GetPriority(IRQn: IRQn);
-    pub fn STATIC_INLINE_NVIC_EncodePriority (PriorityGroup: u32, PreemptPriority: u32, SubPriority: u32);
-    pub fn STATIC_INLINE_NVIC_DecodePriority (Priority: u32, PriorityGroup: u32, pPreemptPriority: *mut u32, pSubPriority: *mut u32);
+    pub fn STATIC_INLINE_NVIC_EnableIRQ(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_DisableIRQ(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_GetPendingIRQ(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_SetPendingIRQ(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_ClearPendingIRQ(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_GetActive(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_SetPriority(irq_n: IRQn, priority: u32);
+    pub fn STATIC_INLINE_NVIC_GetPriority(irq_n: IRQn);
+    pub fn STATIC_INLINE_NVIC_EncodePriority(priority_group: u32, preempt_priority: u32, sub_priority: u32);
+    pub fn STATIC_INLINE_NVIC_DecodePriority(priority: u32, priority_group: u32, p_preempt_priority: *mut u32, p_sub_priority: *mut u32);
     pub fn STATIC_INLINE_NVIC_SystemReset();
 }
 
-pub fn NVIC_SetPriorityGrouping(PriorityGroup: u32) {
-    unsafe { STATIC_INLINE_NVIC_SetPriorityGrouping(PriorityGroup) }
+pub fn set_priority_grouping(priority_group: u32) {
+    unsafe { STATIC_INLINE_NVIC_SetPriorityGrouping(priority_group) }
 }
 
-pub fn NVIC_GetPriorityGrouping() {
+pub fn get_priority_grouping() {
     unsafe { STATIC_INLINE_NVIC_GetPriorityGrouping() }
 }
 
-pub fn enable_IRQ(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_EnableIRQ(IRQn) }
+pub fn enable_irq(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_EnableIRQ(irq_n) }
 }
 
-pub fn NVIC_DisableIRQ(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_DisableIRQ(IRQn) }
+pub fn disable_irq(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_DisableIRQ(irq_n) }
 }
 
-pub fn NVIC_GetPendingIRQ(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_GetPendingIRQ(IRQn) }
+pub fn get_pending_irq(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_GetPendingIRQ(irq_n) }
 }
 
-pub fn NVIC_SetPendingIRQ(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_SetPendingIRQ(IRQn) }
+pub fn set_pending_irq(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_SetPendingIRQ(irq_n) }
 }
 
-pub fn clear_pending_IRQ(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_ClearPendingIRQ(IRQn) }
+pub fn clear_pending_irq(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_ClearPendingIRQ(irq_n) }
 }
 
-pub fn NVIC_GetActive(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_GetActive(IRQn) }
+pub fn get_active(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_GetActive(irq_n) }
 }
 
-pub fn NVIC_SetPriority(IRQn: IRQn, priority: u32) {
-    unsafe { STATIC_INLINE_NVIC_SetPriority(IRQn, priority) }
+pub fn set_priority(irq_n: IRQn, priority: u32) {
+    unsafe { STATIC_INLINE_NVIC_SetPriority(irq_n, priority) }
 }
 
-pub fn NVIC_GetPriority(IRQn: IRQn) {
-    unsafe { STATIC_INLINE_NVIC_GetPriority(IRQn) }
+pub fn get_priority(irq_n: IRQn) {
+    unsafe { STATIC_INLINE_NVIC_GetPriority(irq_n) }
 }
 
-pub fn NVIC_EncodePriority(PriorityGroup: u32, PreemptPriority: u32, SubPriority: u32) {
-    unsafe { STATIC_INLINE_NVIC_EncodePriority(PriorityGroup, PreemptPriority, SubPriority) }
+pub fn encode_priority(priority_group: u32, preempt_priority: u32, sub_priority: u32) {
+    unsafe { STATIC_INLINE_NVIC_EncodePriority(priority_group, preempt_priority, sub_priority) }
 }
 
-pub fn NVIC_DecodePriority(Priority: u32, PriorityGroup: u32, pPreemptPriority: *mut u32, pSubPriority: *mut u32) {
-    unsafe { STATIC_INLINE_NVIC_DecodePriority(Priority, PriorityGroup, pPreemptPriority, pSubPriority) }
+pub fn decode_priority(priority: u32, priority_group: u32, p_preempt_priority: *mut u32, p_sub_priority: *mut u32) {
+    unsafe { STATIC_INLINE_NVIC_DecodePriority(priority, priority_group, p_preempt_priority, p_sub_priority) }
 }
 
-pub fn NVIC_SystemReset() {
+pub fn system_reset() {
     unsafe { STATIC_INLINE_NVIC_SystemReset() }
 }
-

--- a/src/cmsis/nvic.rs
+++ b/src/cmsis/nvic.rs
@@ -1,4 +1,5 @@
 #[repr(C)]
+#[derive(Copy)]
 pub enum IRQn {
 /******  Cortex-M3 Processor Exceptions Numbers *******************************************/
     NonMaskableInt   = -14,

--- a/src/emlib/mod.rs
+++ b/src/emlib/mod.rs
@@ -1,3 +1,0 @@
-pub mod chip;
-pub mod cmu;
-pub mod gpio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate core;
 
 pub mod chip;
 pub mod cmu;
+pub mod emu;
 pub mod gpio;
 pub mod rtc;
 pub mod timer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![crate_type="lib"]
 #![crate_name="emlib"]
+#![deny(warnings)]
 #![feature(core, lang_items, no_std)]
 
 extern crate core;
@@ -8,6 +9,7 @@ extern crate core;
 pub mod chip;
 pub mod cmu;
 pub mod gpio;
+pub mod rtc;
 pub mod timer;
 
 pub mod emdrv;

--- a/src/rtc/mod.rs
+++ b/src/rtc/mod.rs
@@ -4,6 +4,7 @@ use core::default::Default;
 pub const RTC_IEN_COMP0: u32 = (0x1 << 1);
 
 #[repr(C)]
+#[derive(Copy)]
 pub struct Init {
     pub enable: bool,
     pub debug_run: bool,

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -13,6 +13,7 @@ pub const TIMER_IF_ICBOF1: u32 = (0x1 << 9);
 pub const TIMER_IF_ICBOF2: u32 = (0x1 << 10);
 
 #[repr(C)]
+#[derive(Copy)]
 #[allow(non_snake_case)]
 pub struct CC {
     pub CTRL: u32,
@@ -22,6 +23,7 @@ pub struct CC {
 }
 
 #[repr(C)]
+#[derive(Copy)]
 #[allow(non_snake_case)]
 pub struct Timer {
     pub CTRL: u32,


### PR DESCRIPTION
- Fixed warnings issued by new Rust version
- Renamed the functions and paramters in the `nvic` module.
- Deleted old and unused `emlib` module
- Added `energy_modes` and `rtc_blink` examples.
- Add `test` to Makefile. It looks up every `examples/*.rs` file and builds them. This should ensure that the examples are up to date with the library.
