### PR TITLE
Configured the examples with reference to correct panic_fmt

### DIFF
--- a/examples/buttons_int.rs
+++ b/examples/buttons_int.rs
@@ -56,6 +56,14 @@ pub extern fn main() {
     loop {}
 }
 
-#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "stack_exhausted"]
+pub extern fn stack_exhausted() {}
+
+#[lang = "eh_personality"]
+pub extern fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+#[allow(unused_variables)]
+pub extern fn rust_begin_unwind(msg: core::fmt::Arguments, file: &'static str, line: usize) -> ! {
+    loop { }
+}

--- a/examples/dma.rs
+++ b/examples/dma.rs
@@ -25,14 +25,14 @@ pub extern fn main() {
 
     let dma0 = dma::DMA::channel0();
     unsafe { dma0.activate_auto(true, &mut DATA_DST, &mut DATA_SRC); }
-    
+
     loop {}
 }
 
 extern fn transfer_complete(_channel: u32, _primary: bool, _user: u32) {}
 
 fn setup_dma() {
-    
+
     dma::init(&dma::Init{
         hprot: 0,
         control_block: dma::dma_control_block(),
@@ -44,7 +44,7 @@ fn setup_dma() {
         enable_int: true,
         select: 0,
         cb: &CB,
-    }); 
+    });
     dma0.configure_descriptor(true, &dma::CfgDescriptor {
         dst_inc: dma::DataInc::Inc4,
         src_inc: dma::DataInc::Inc4,
@@ -54,6 +54,14 @@ fn setup_dma() {
     });
 }
 
-#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "stack_exhausted"]
+pub extern fn stack_exhausted() {}
+
+#[lang = "eh_personality"]
+pub extern fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+#[allow(unused_variables)]
+pub extern fn rust_begin_unwind(msg: core::fmt::Arguments, file: &'static str, line: usize) -> ! {
+    loop { }
+}

--- a/examples/energy_modes.rs
+++ b/examples/energy_modes.rs
@@ -57,6 +57,14 @@ pub extern fn main() {
     }
 }
 
-#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "stack_exhausted"]
+pub extern fn stack_exhausted() {}
+
+#[lang = "eh_personality"]
+pub extern fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+#[allow(unused_variables)]
+pub extern fn rust_begin_unwind(msg: core::fmt::Arguments, file: &'static str, line: usize) -> ! {
+    loop { }
+}

--- a/examples/rtc_blink.rs
+++ b/examples/rtc_blink.rs
@@ -31,7 +31,7 @@ fn rtc_setup() {
     rtc::init(&rtc_init);
 
     /* Interrupt every second */
-    rtc::compare_set(0, LFXO_FREQ * RTC_TIMEOUT_S);
+    rtc::compare_set(0, (LFXO_FREQ * RTC_TIMEOUT_S) / 2);
 
     /* Enable interrupt */
     nvic::enable_irq(nvic::IRQn::RTC);
@@ -66,8 +66,17 @@ pub extern fn RTC_IRQHandler() {
     rtc::int_clear(rtc::RTC_IEN_COMP0);
 
     gpio::pin_out_toggle(gpio::Port::E, 2);
+
 }
 
-#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "stack_exhausted"]
+pub extern fn stack_exhausted() {}
+
+#[lang = "eh_personality"]
+pub extern fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+#[allow(unused_variables)]
+pub extern fn rust_begin_unwind(msg: core::fmt::Arguments, file: &'static str, line: usize) -> ! {
+    loop { }
+}

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -47,6 +47,14 @@ pub extern fn main() {
     loop {}
 }
 
-#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "stack_exhausted"]
+pub extern fn stack_exhausted() {}
+
+#[lang = "eh_personality"]
+pub extern fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+#[allow(unused_variables)]
+pub extern fn rust_begin_unwind(msg: core::fmt::Arguments, file: &'static str, line: usize) -> ! {
+    loop { }
+}


### PR DESCRIPTION
To test: Set a breakpoint on `example/rust_begin_unwind` and insert a divide by zero somewhere in the code. It should now be able to print msg, file and line when debugging the error.
