### PR TITLE
Emlib timer tests

### DIFF
--- a/build/emlib.rs
+++ b/build/emlib.rs
@@ -68,6 +68,7 @@ fn prod_config(config: &mut Config) -> &mut Config {
     base_config(config)
 
         .include("efm32-common/kits/common/bsp")
+        .include("src/timer")
 
         .file("efm32-common/emlib/src/em_dma.c")
         .file("efm32-common/emlib/src/em_rtc.c")
@@ -83,6 +84,8 @@ fn prod_config(config: &mut Config) -> &mut Config {
         .file("src/rtc/rtc.c")
         .file("src/timer/timer.c")
         .file("src/usart/usart.c")
+
+        .file("src/timer/get_timer.c")
 
         .include("efm32-common/emdrv/gpiointerrupt/inc")
         .file("efm32-common/emdrv/gpiointerrupt/src/gpiointerrupt.c")
@@ -103,12 +106,14 @@ fn test_config(config: &mut Config) -> &mut Config {
 
         .include("test/lib/Unity/src")
         .include("test/lib/cmock/src")
+        .include("src/timer")
 
         .file("src/chip/chip.c")
         .file("src/cmsis/cmsis.c")
-        .file("src/timer/timer.c")
         .file("src/gpio/gpio.c")
         .file("src/usart/usart.c")
+
+        .file("src/timer/get_timer.c")
 
         .file("test/lib/Unity/src/unity.c")
         .file("test/lib/cmock/src/cmock.c")
@@ -117,6 +122,7 @@ fn test_config(config: &mut Config) -> &mut Config {
         // Mocks
         .include("test/mocks")
         .file("test/mocks/Mockem_timer.c")
+        .file("test/mocks/Mocktimer.c")
 
         // Tests
         .file("test/tests/timer.c")

--- a/build/emlib.rs
+++ b/build/emlib.rs
@@ -39,7 +39,7 @@ fn compile_emlib_library() {
 
 
 fn base_config(config: &mut Config) -> &mut Config {
-    
+
     config
         .define("EFM32GG990F1024", None)
 
@@ -47,7 +47,7 @@ fn base_config(config: &mut Config) -> &mut Config {
         .include("efm32-common/Device/EFM32GG/Include")
         .include("efm32-common/kits/EFM32GG_STK3700/config")
         .include("efm32-common/emlib/inc")
-        
+
         .file("efm32-common/Device/EFM32GG/Source/GCC/startup_efm32gg.S")
         .file("efm32-common/Device/EFM32GG/Source/system_efm32gg.c")
 
@@ -55,7 +55,7 @@ fn base_config(config: &mut Config) -> &mut Config {
         .file("efm32-common/emlib/src/em_gpio.c")
         .file("efm32-common/emlib/src/em_usart.c")
         .file("efm32-common/emlib/src/em_emu.c")
-        
+
         .flag("-g")
         .flag("-Wall")
         .flag("-mthumb")
@@ -64,11 +64,11 @@ fn base_config(config: &mut Config) -> &mut Config {
 }
 
 fn prod_config(config: &mut Config) -> &mut Config {
-    
+
     base_config(config)
 
         .include("efm32-common/kits/common/bsp")
-        
+
         .file("efm32-common/emlib/src/em_dma.c")
         .file("efm32-common/emlib/src/em_rtc.c")
         .file("efm32-common/emlib/src/em_system.c")
@@ -103,7 +103,7 @@ fn test_config(config: &mut Config) -> &mut Config {
 
         .include("test/lib/Unity/src")
         .include("test/lib/cmock/src")
-        
+
         .file("src/chip/chip.c")
         .file("src/cmsis/cmsis.c")
         .file("src/timer/timer.c")
@@ -113,15 +113,13 @@ fn test_config(config: &mut Config) -> &mut Config {
         .file("test/lib/Unity/src/unity.c")
         .file("test/lib/cmock/src/cmock.c")
         .file("test/util/usart_print.c")
-        
+
         // Mocks
         .include("test/mocks")
         .file("test/mocks/Mockem_timer.c")
 
         // Tests
         .file("test/tests/timer.c")
-
-
 }
 
 fn write_emlib_hash() -> IoResult<()> {

--- a/src/timer/get_timer.c
+++ b/src/timer/get_timer.c
@@ -1,0 +1,17 @@
+#include "em_timer.h"
+
+TIMER_TypeDef* GET_TIMER0() {
+    return TIMER0;
+}
+
+TIMER_TypeDef* GET_TIMER1() {
+    return TIMER1;
+}
+
+TIMER_TypeDef* GET_TIMER2() {
+    return TIMER2;
+}
+
+TIMER_TypeDef* GET_TIMER3() {
+    return TIMER3;
+}

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -59,7 +59,7 @@ void STATIC_INLINE_TIMER_IntClear(TIMER_TypeDef *timer, uint32_t flags) {
 void STATIC_INLINE_TIMER_IntDisable(TIMER_TypeDef *timer, uint32_t flags) {
     TIMER_IntDisable(timer, flags);
 }
-    
+
 void STATIC_INLINE_TIMER_IntEnable(TIMER_TypeDef *timer, uint32_t flags) {
     TIMER_IntEnable(timer, flags);
 }

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -1,20 +1,5 @@
 #include "em_timer.h"
 
-TIMER_TypeDef* GET_TIMER0() {
-    return TIMER0;
-}
-
-TIMER_TypeDef* GET_TIMER1() {
-    return TIMER1;
-}
-
-TIMER_TypeDef* GET_TIMER2() {
-    return TIMER2;
-}
-
-TIMER_TypeDef* GET_TIMER3() {
-    return TIMER3;
-}
 
 uint32_t STATIC_INLINE_TIMER_CaptureGet(TIMER_TypeDef *timer, unsigned int ch) {
     return TIMER_CaptureGet(timer, ch);

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -1,0 +1,22 @@
+#include "em_timer.h"
+
+uint32_t STATIC_INLINE_TIMER_CaptureGet(TIMER_TypeDef *timer, unsigned int ch);
+void STATIC_INLINE_TIMER_CompareBufSet(TIMER_TypeDef *timer, unsigned int ch, uint32_t val);
+void STATIC_INLINE_TIMER_CompareSet(TIMER_TypeDef *timer, unsigned int ch, uint32_t val);
+uint32_t STATIC_INLINE_TIMER_CounterGet(TIMER_TypeDef *timer);
+void STATIC_INLINE_TIMER_CounterSet(TIMER_TypeDef *timer, uint32_t val);
+void STATIC_INLINE_TIMER_Enable(TIMER_TypeDef *timer, bool enable);
+void STATIC_INLINE_TIMER_EnableDTI(TIMER_TypeDef *timer, bool enable);
+uint32_t STATIC_INLINE_TIMER_GetDTIFault(TIMER_TypeDef *timer);
+void STATIC_INLINE_TIMER_ClearDTIFault(TIMER_TypeDef *timer, uint32_t flags);
+void STATIC_INLINE_TIMER_IntClear(TIMER_TypeDef *timer, uint32_t flags);
+void STATIC_INLINE_TIMER_IntDisable(TIMER_TypeDef *timer, uint32_t flags);
+void STATIC_INLINE_TIMER_IntEnable(TIMER_TypeDef *timer, uint32_t flags);
+uint32_t STATIC_INLINE_TIMER_IntGet(TIMER_TypeDef *timer);
+uint32_t STATIC_INLINE_TIMER_IntGetEnabled(TIMER_TypeDef *timer);
+void STATIC_INLINE_TIMER_IntSet(TIMER_TypeDef *timer, uint32_t flags);
+void STATIC_INLINE_TIMER_Lock(TIMER_TypeDef *timer);
+void STATIC_INLINE_TIMER_TopBufSet(TIMER_TypeDef *timer, uint32_t val);
+uint32_t STATIC_INLINE_TIMER_TopGet(TIMER_TypeDef *timer);
+void STATIC_INLINE_TIMER_TopSet(TIMER_TypeDef *timer, uint32_t val);
+void STATIC_INLINE_TIMER_Unlock(TIMER_TypeDef *timer);

--- a/test/tests/timer.c
+++ b/test/tests/timer.c
@@ -32,3 +32,9 @@ void expect_reset_called() {
     TIMER_Reset_Expect(TIMER0);
 
 }
+
+void expect_enable_called() {
+
+    STATIC_INLINE_TIMER_Enable_Expect(TIMER0, true);
+
+}

--- a/test/tests/timer.c
+++ b/test/tests/timer.c
@@ -23,4 +23,11 @@ void expect_init_dti_called_with_default() {
 
     static TIMER_InitDTI_TypeDef timer_init_dti = TIMER_INITDTI_DEFAULT;
     TIMER_InitDTI_Expect(TIMER0, &timer_init_dti);
+
+}
+
+void expect_reset_called() {
+
+    TIMER_Reset_Expect(TIMER0);
+
 }

--- a/test/tests/timer.c
+++ b/test/tests/timer.c
@@ -11,3 +11,16 @@ void expect_init_called_with_default() {
     TIMER_Init_Expect(TIMER0, &timer_init);
 
 }
+
+void expect_init_cc_called_with_default() {
+
+    static TIMER_InitCC_TypeDef timer_init_cc = TIMER_INITCC_DEFAULT;
+    TIMER_InitCC_Expect(TIMER0, 0, &timer_init_cc);
+
+}
+
+void expect_init_dti_called_with_default() {
+
+    static TIMER_InitDTI_TypeDef timer_init_dti = TIMER_INITDTI_DEFAULT;
+    TIMER_InitDTI_Expect(TIMER0, &timer_init_dti);
+}

--- a/test/tests/timer.c
+++ b/test/tests/timer.c
@@ -5,7 +5,7 @@
 #include "cmock.h"
 #include "Mockem_timer.h"
 
-void expect_init_called() {
+void expect_init_called_with_default() {
 
     static TIMER_Init_TypeDef timer_init = TIMER_INIT_DEFAULT;
     TIMER_Init_Expect(TIMER0, &timer_init);

--- a/test/tests/timer.c
+++ b/test/tests/timer.c
@@ -3,6 +3,7 @@
 
 #include "unity.h"
 #include "cmock.h"
+#include "Mocktimer.h"
 #include "Mockem_timer.h"
 
 void expect_init_called_with_default() {

--- a/test/tests/timer.rs
+++ b/test/tests/timer.rs
@@ -7,9 +7,9 @@ fn setup() { unsafe { Mockem_timer_Init() } }
 fn tear_down() { unsafe { Mockem_timer_Verify() } }
 fn tear_down_tests() { unsafe { Mockem_timer_Destroy() } }
 
-fn test_init_called() {
+fn test_init_called_with_default() {
 
-    unsafe { expect_init_called(); }
+    unsafe { expect_init_called_with_default(); }
     
     let timer = timer::Timer::timer0();
     timer.init(&Default::default());
@@ -19,7 +19,7 @@ pub fn run_tests() {
     let usart1 = usart::Usart::usart1();
 
     let tests: [fn(); 1] = [
-        test_init_called,
+        test_init_called_with_default,
     ];
 
     for test in tests.iter() {
@@ -38,5 +38,5 @@ extern {
     fn Mockem_timer_Destroy();
     fn Mockem_timer_Verify();
 
-    fn expect_init_called();
+    fn expect_init_called_with_default();
 }

--- a/test/tests/timer.rs
+++ b/test/tests/timer.rs
@@ -54,14 +54,24 @@ fn test_reset_called() {
     timer.reset();
 }
 
+fn test_enable_called() {
+
+    unsafe { expect_enable_called(); }
+
+    let timer = timer::Timer::timer0();
+    timer.enable(true);
+
+}
+
 pub fn run_tests() {
     let usart1 = usart::Usart::usart1();
 
-    let tests: [fn(); 4] = [
+    let tests: [fn(); 5] = [
         test_init_called_with_default,
         test_init_cc_called_with_default,
         test_init_dti_called_with_default,
         test_reset_called,
+        test_enable_called,
     ];
 
     for test in tests.iter() {
@@ -88,4 +98,5 @@ extern {
     fn expect_init_cc_called_with_default();
     fn expect_init_dti_called_with_default();
     fn expect_reset_called();
+    fn expect_enable_called();
 }

--- a/test/tests/timer.rs
+++ b/test/tests/timer.rs
@@ -10,7 +10,7 @@ fn tear_down_tests() { unsafe { Mockem_timer_Destroy() } }
 fn test_init_called_with_default() {
 
     unsafe { expect_init_called_with_default(); }
-    
+
     let timer = timer::Timer::timer0();
     timer.init(&Default::default());
 }

--- a/test/tests/timer.rs
+++ b/test/tests/timer.rs
@@ -15,11 +15,29 @@ fn test_init_called_with_default() {
     timer.init(&Default::default());
 }
 
+fn test_init_cc_called_with_default() {
+
+    unsafe { expect_init_cc_called_with_default(); }
+
+    let timer = timer::Timer::timer0();
+    timer.init_cc(0, &Default::default());
+}
+
+fn test_init_dti_called_with_default() {
+
+    unsafe { expect_init_dti_called_with_default(); }
+
+    let timer = timer::Timer::timer0();
+    timer.init_dti(&Default::default());
+}
+
 pub fn run_tests() {
     let usart1 = usart::Usart::usart1();
 
-    let tests: [fn(); 1] = [
+    let tests: [fn(); 3] = [
         test_init_called_with_default,
+        test_init_cc_called_with_default,
+        test_init_dti_called_with_default,
     ];
 
     for test in tests.iter() {
@@ -39,4 +57,6 @@ extern {
     fn Mockem_timer_Verify();
 
     fn expect_init_called_with_default();
+    fn expect_init_cc_called_with_default();
+    fn expect_init_dti_called_with_default();
 }

--- a/test/tests/timer.rs
+++ b/test/tests/timer.rs
@@ -3,9 +3,24 @@ use emlib::usart;
 use core::default::Default;
 use core::slice::SliceExt;
 
-fn setup() { unsafe { Mockem_timer_Init() } }
-fn tear_down() { unsafe { Mockem_timer_Verify() } }
-fn tear_down_tests() { unsafe { Mockem_timer_Destroy() } }
+fn setup() {
+    unsafe {
+        Mocktimer_Init();
+        Mockem_timer_Init();
+    }
+}
+fn tear_down() {
+    unsafe {
+        Mocktimer_Verify();
+        Mockem_timer_Verify();
+    }
+}
+fn tear_down_tests() {
+    unsafe {
+        Mocktimer_Destroy();
+        Mockem_timer_Destroy();
+    }
+}
 
 fn test_init_called_with_default() {
 
@@ -60,6 +75,10 @@ pub fn run_tests() {
 }
 
 extern {
+
+    fn Mocktimer_Init();
+    fn Mocktimer_Destroy();
+    fn Mocktimer_Verify();
 
     fn Mockem_timer_Init();
     fn Mockem_timer_Destroy();

--- a/test/tests/timer.rs
+++ b/test/tests/timer.rs
@@ -31,13 +31,22 @@ fn test_init_dti_called_with_default() {
     timer.init_dti(&Default::default());
 }
 
+fn test_reset_called() {
+
+    unsafe { expect_reset_called(); }
+
+    let timer = timer::Timer::timer0();
+    timer.reset();
+}
+
 pub fn run_tests() {
     let usart1 = usart::Usart::usart1();
 
-    let tests: [fn(); 3] = [
+    let tests: [fn(); 4] = [
         test_init_called_with_default,
         test_init_cc_called_with_default,
         test_init_dti_called_with_default,
+        test_reset_called,
     ];
 
     for test in tests.iter() {
@@ -59,4 +68,5 @@ extern {
     fn expect_init_called_with_default();
     fn expect_init_cc_called_with_default();
     fn expect_init_dti_called_with_default();
+    fn expect_reset_called();
 }


### PR DESCRIPTION
Requires `ruby lib/cmock/lib/cmock.rb -ocmock.yml ../src/timer/timer.h` executed in test directory.
