### PR TITLE
Update to RustyGecko/rlibc dependency and update target directory naming...

### DIFF
--- a/.execute.jlink
+++ b/.execute.jlink
@@ -1,5 +1,5 @@
 device EFM32GG990F1024
-loadbin target/thumbv7m-none-eabi/out.hex, 0x00
+loadbin target/thumbv7m-none-eabi/debug/out.hex, 0x00
 r
 g
 q

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ git = "https://github.com/RustyGecko/rust-collections.git"
 git = "https://github.com/RustyGecko/rust-libc.git"
 
 [target.thumbv7m-none-eabi.dependencies.rlibc]
-git = "https://github.com/havardh/rust-librlibc.git"
+git = "https://github.com/RustyGecko/rlibc.git"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ FLASH = eACommander
 
 -include .emlib_hash
 
-TARGET_DIR = target/$(TARGET)
+TARGET_DIR = target/$(TARGET)/debug
 TARGET_OUT = $(TARGET_DIR)/$(EX)
 
 .PHONY: all setup proj flash test clean

--- a/build/emlib.rs
+++ b/build/emlib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![feature(core, fs, io, old_path)]
+#![feature(core, io, old_path)]
 
 extern crate gcc;
 


### PR DESCRIPTION
... according to updated cargo naming conventions
